### PR TITLE
added actual support of wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ const PUBLIC_DIR = "./public"; // Change to your preferred directory
 - JSON (`.json`)
 - Images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.ico`)
 - Text files (`.txt`)
+- WebAssembly (`.wasm`)
 
 ## Development
 

--- a/hot-reload.ts
+++ b/hot-reload.ts
@@ -16,7 +16,8 @@ const mimeTypes: Record<string, string> = {
   ".gif": "image/gif",
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
-  ".txt": "text/plain"
+  ".txt": "text/plain",
+  ".wasm": "application/wasm"
 };
 
 const clients = new Set<WebSocket>();

--- a/static-server.ts
+++ b/static-server.ts
@@ -16,7 +16,8 @@ const mimeTypes: Record<string, string> = {
   ".gif": "image/gif",
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
-  ".txt": "text/plain"
+  ".txt": "text/plain",
+  ".wasm": "application/wasm"
 };
 
 function getMimeType(filePath: string): string {


### PR DESCRIPTION
By adding those simple mime types the client can use `WebAssembly.instantiateStreaming` API instead of `WebAssembly.instantiate` API to load wasm which is better.